### PR TITLE
Update tray tooltip to match CachyOS branding

### DIFF
--- a/src/lib/tray.py
+++ b/src/lib/tray.py
@@ -312,7 +312,7 @@ class ArchUpdateQt6:
         self.tray.activated.connect(self.run)
 
         # Tooltip
-        tooltip = _("Arch-Update")
+        tooltip = _("Cachy-Update")
         self.tray.setToolTip(tooltip)
 
         # Definition of menus titles


### PR DESCRIPTION
### Description

Update Tray's tooltip to match CachyOS branding

### Screenshots

Before:
<img width="420" height="112" alt="image" src="https://github.com/user-attachments/assets/5614c69f-6c68-4f66-ad3d-203edc4234c2" />

After:

<img width="420" height="112" alt="image" src="https://github.com/user-attachments/assets/f4831035-5448-4070-8eab-a4be0d795559" />