### PR TITLE
chore(systray): Hide arch-update-tray.desktop from application launcher

### DIFF
--- a/res/desktop/arch-update-tray.desktop
+++ b/res/desktop/arch-update-tray.desktop
@@ -14,3 +14,4 @@ Icon=cachy-update_updates-available-blue
 Type=Application
 Exec=arch-update --tray
 Categories=Utility
+NoDisplay=true


### PR DESCRIPTION
### Description
This adds `NoDisplay=true` to arch-update-tray.desktop, as it shouldn't appear in the application launcher/menu.

https://specifications.freedesktop.org/desktop-entry/0.9.5/recognized-keys.html#:~:text=NoDisplay